### PR TITLE
Support 32bit Windows hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build:
 build-release:
 	GOARM=7 gox -verbose \
 	-ldflags "-X main.version=${VERSION}" \
-	-osarch="windows/amd64 linux/386 linux/amd64 darwin/amd64 linux/arm linux/arm64" \
+	-osarch="windows/386 windows/amd64 linux/386 linux/amd64 darwin/amd64 linux/arm linux/arm64" \
 	-output="release/{{.Dir}}-${VERSION}-{{.OS}}-{{.Arch}}" .
 
 install: build

--- a/install.ps1
+++ b/install.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = "Stop"
 
 $jabbaHome = if ($env:JABBA_HOME) { $env:JABBA_HOME } else { if ($env:JABBA_DIR) { $env:JABBA_DIR } else { "$env:USERPROFILE\.jabba" } }
 $jabbaVersion = if ($env:JABBA_VERSION) { $env:JABBA_VERSION } else { "latest" }
+$jabbaArch = if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") { "amd64" } else { "386" }
 
 if ($jabbaVersion -eq "latest")
 {
@@ -25,7 +26,7 @@ if ($env:JABBA_MAKE_INSTALL -eq "true")
 }
 else
 {
-    Invoke-WebRequest https://github.com/Jabba-Team/jabba/releases/download/$jabbaVersion/jabba-$jabbaVersion-windows-amd64.exe -UseBasicParsing -OutFile $jabbaHome/bin/jabba.exe
+    Invoke-WebRequest https://github.com/Jabba-Team/jabba/releases/download/$jabbaVersion/jabba-$jabbaVersion-windows-$jabbaArch.exe -UseBasicParsing -OutFile $jabbaHome/bin/jabba.exe
 }
 
 $ErrorActionPreference="SilentlyContinue"

--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,8 @@ case "$OSTYPE" in
     OS_ARCH=$(echo 'echo %PROCESSOR_ARCHITECTURE% & exit' | cmd | tail -n 1 | xargs) # xargs used to trim whitespace
     if [ "$OS_ARCH" == "AMD64" ]; then
         BINARY_URL="https://github.com/Jabba-Team/jabba/releases/download/${JABBA_VERSION}/jabba-${JABBA_VERSION}-windows-amd64.exe"
+    elif [ "$OS_ARCH" == "x86" ]; then
+        BINARY_URL="https://github.com/Jabba-Team/jabba/releases/download/${JABBA_VERSION}/jabba-${JABBA_VERSION}-windows-386.exe"
     else
         echo "OS_ARCH='$OS_ARCH' is not a valid architecture at this point."
         exit 1


### PR DESCRIPTION
This is a little cumbersome to test without a release but I ran both the shell script and the PowerShell script on a Windows 10 32bit host and checked it tries to download the correct binary. Afterwards, I copied the 32bit `jabba` binary manually to `~/.jabba/bin/jabba` and verified it works.