### PR TITLE
Allow install location customizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build-release:
 	-output="release/{{.Dir}}-${VERSION}-{{.OS}}-{{.Arch}}" .
 
 install: build
-	JABBA_MAKE_INSTALL=true JABBA_VERSION=${VERSION} sh install.sh
+	JABBA_MAKE_INSTALL=true JABBA_VERSION=${VERSION} bash install.sh
 
 publish: clean build-release
 	test -n "$(GITHUB_TOKEN)" # $$GITHUB_TOKEN must be set

--- a/install.sh
+++ b/install.sh
@@ -36,9 +36,9 @@ https_proxy=${https_proxy:-$HTTPS_PROXY}
 HTTPS_PROXY=${HTTPS_PROXY:-$https_proxy}
 
 if [ "$JABBA_GET" == "" ]; then
-    if [ 0 -eq  $(has_command curl) ]; then
+    if [ 0 -eq "$(has_command curl)" ]; then
         JABBA_GET="curl -sL"
-    elif [ 0 -eq $(has_command wget) ]; then
+    elif [ 0 -eq "$(has_command wget)" ]; then
         JABBA_GET="wget -qO-"
     else
         echo "[ERROR] This script needs wget or curl to be installed."
@@ -179,10 +179,10 @@ if [ ! "$SKIP_RC" ]; then
 
     for file in "${files[@]}"
     do
-        touch ${file}
+        touch "${file}"
         if ! grep -qc '/jabba.sh' "${file}"; then
             echo "Adding source string to ${file}"
-            printf "$SOURCE_JABBA\n" >> "${file}"
+            printf "%s\n" "$SOURCE_JABBA" >> "${file}"
         else
             echo "Skipped update of ${file} (source string already present)"
         fi
@@ -190,10 +190,10 @@ if [ ! "$SKIP_RC" ]; then
 
     if [ -f "$(which zsh 2>/dev/null)" ]; then
         file="$HOME/.zshrc"
-        touch ${file}
+        touch "${file}"
         if ! grep -qc '/jabba.sh' "${file}"; then
             echo "Adding source string to ${file}"
-            printf "$SOURCE_JABBA\n" >> "${file}"
+            printf "%s\n" "$SOURCE_JABBA" >> "${file}"
         else
             echo "Skipped update of ${file} (source string already present)"
         fi
@@ -222,11 +222,11 @@ FISH_SOURCE_JABBA="\n[ -s \"$JABBA_HOME/jabba.fish\" ]; and source \"$JABBA_HOME
 
 if [ -f "$(which fish 2>/dev/null)" ]; then
     file="$HOME/.config/fish/config.fish"
-    mkdir -p $(dirname ${file})
-    touch ${file}
+    mkdir -p "$(dirname "${file}")"
+    touch "${file}"
     if ! grep -qc '/jabba.fish' "${file}"; then
         echo "Adding source string to ${file}"
-        printf "$FISH_SOURCE_JABBA\n" >> "${file}"
+        printf "%s\n" "$FISH_SOURCE_JABBA" >> "${file}"
     else
         echo "Skipped update of ${file} (source string already present)"
     fi

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,11 @@ else
     JABBA_HOME_TO_EXPORT=$JABBA_HOME
 fi
 
+# Install location customizations
+JABBA_BIN=${JABBA_BIN:-"$JABBA_HOME/bin"}
+JABBA_BIN_TO_EXPORT=${JABBA_BIN_TO_EXPORT:-"$JABBA_HOME_TO_EXPORT/bin"}
+JABBA_SHARE=${JABBA_SHARE:-$JABBA_HOME}
+
 has_command() {
     if ! command -v "$1" > /dev/null 2>&1
     then echo 1;
@@ -113,20 +118,21 @@ esac
 echo "Installing v$JABBA_VERSION..."
 echo
 
-if [ ! -f "${JABBA_HOME}/bin/jabba" ]; then
+if [ ! -f "${JABBA_BIN}/jabba" ]; then
     JABBA_SELF_DESTRUCT_AFTER_COMMAND="true"
 fi
 
-mkdir -p ${JABBA_HOME}/bin
+mkdir -p "${JABBA_SHARE}"
+mkdir -p "${JABBA_BIN}"
 
 if [ "$JABBA_MAKE_INSTALL" == "true" ]; then
-    cp jabba ${JABBA_HOME}/bin
+    cp jabba "${JABBA_BIN}"
 else
-    $JABBA_GET ${BINARY_URL} > ${JABBA_HOME}/bin/jabba && chmod a+x ${JABBA_HOME}/bin/jabba
+    $JABBA_GET "${BINARY_URL}" > "${JABBA_BIN}/jabba" && chmod a+x "${JABBA_BIN}/jabba"
 fi
 
-if ! ${JABBA_HOME}/bin/jabba --version &>/dev/null; then
-    echo "${JABBA_HOME}/bin/jabba does not appear to be a valid binary.
+if ! "${JABBA_BIN}/jabba" --version &>/dev/null; then
+    echo "${JABBA_BIN}/jabba does not appear to be a valid binary.
 
 Check your Internet connection / proxy settings and try again.
 If the problem persists - please create a ticket at https://github.com/Jabba-Team/jabba/issues."
@@ -134,35 +140,17 @@ If the problem persists - please create a ticket at https://github.com/Jabba-Tea
 fi
 
 if [ "$JABBA_COMMAND" != "" ]; then
-    ${JABBA_HOME}/bin/jabba $JABBA_COMMAND
+    "${JABBA_BIN}/jabba" "$JABBA_COMMAND"
     if [ "$JABBA_SELF_DESTRUCT_AFTER_COMMAND" == "true" ]; then
-        rm -f ${JABBA_HOME}/bin/jabba
-        rmdir ${JABBA_HOME}/bin
+        rm -f "${JABBA_BIN}/jabba"
+        rmdir "${JABBA_BIN}"
         exit 0
     fi
 fi
 
-{
-echo "# https://github.com/Jabba-Team/jabba"
-echo "# This file is intended to be \"sourced\" (i.e. \". ~/.jabba/jabba.sh\")"
-echo ""
-echo "export JABBA_HOME=\"$JABBA_HOME_TO_EXPORT\""
-echo ""
-echo "jabba() {"
-echo "    local fd3=\$(mktemp /tmp/jabba-fd3.XXXXXX)"
-echo "    (JABBA_SHELL_INTEGRATION=ON $JABBA_HOME_TO_EXPORT/bin/jabba \"\$@\" 3>| \${fd3})"
-echo "    local exit_code=\$?"
-echo "    eval \$(cat \${fd3})"
-echo "    rm -f \${fd3}"
-echo "    return \${exit_code}"
-echo "}"
-echo ""
-echo "if [ ! -z \"\$(jabba alias default)\" ]; then"
-echo "    jabba use default"
-echo "fi"
-} > ${JABBA_HOME}/jabba.sh
+sed -e "s=\$JABBA_HOME_TO_EXPORT=$JABBA_HOME_TO_EXPORT=g" -e "s=\$JABBA_BIN_TO_EXPORT=$JABBA_BIN_TO_EXPORT=g" jabba.sh > "${JABBA_SHARE}/jabba.sh"
 
-SOURCE_JABBA="\n[ -s \"$JABBA_HOME/jabba.sh\" ] && source \"$JABBA_HOME/jabba.sh\""
+SOURCE_JABBA="\n[ -s \"$JABBA_SHARE/jabba.sh\" ] && source \"$JABBA_SHARE/jabba.sh\""
 
 if [ ! "$SKIP_RC" ]; then
     files=("$HOME/.bashrc")
@@ -200,25 +188,9 @@ if [ ! "$SKIP_RC" ]; then
     fi
 fi
 
-{
-echo "# https://github.com/Jabba-Team/jabba"
-echo "# This file is intended to be \"sourced\" (i.e. \". ~/.jabba/jabba.fish\")"
-echo ""
-echo "set -xg JABBA_HOME \"$JABBA_HOME_TO_EXPORT\""
-echo ""
-echo "function jabba"
-echo "    set fd3 (mktemp /tmp/jabba-fd3.XXXXXX)"
-echo "    env JABBA_SHELL_INTEGRATION=ON $JABBA_HOME_TO_EXPORT/bin/jabba \$argv 3> \$fd3"
-echo "    set exit_code \$status"
-echo "    eval (cat \$fd3 | sed \"s/^export/set -xg/g\" | sed \"s/^unset/set -e/g\" | tr '=' ' ' | sed \"s/:/\\\" \\\"/g\" | tr '\\\\n' ';')"
-echo "    rm -f \$fd3"
-echo "    return \$exit_code"
-echo "end"
-echo ""
-echo "[ ! -z (echo (jabba alias default)) ]; and jabba use default"
-} > ${JABBA_HOME}/jabba.fish
+sed -e "s=\$JABBA_HOME_TO_EXPORT=$JABBA_HOME_TO_EXPORT=g" -e "s=\$JABBA_BIN_TO_EXPORT=$JABBA_BIN_TO_EXPORT=g" jabba.fish > "${JABBA_SHARE}/jabba.fish"
 
-FISH_SOURCE_JABBA="\n[ -s \"$JABBA_HOME/jabba.fish\" ]; and source \"$JABBA_HOME/jabba.fish\""
+FISH_SOURCE_JABBA="\n[ -s \"$JABBA_SHARE/jabba.fish\" ]; and source \"$JABBA_SHARE/jabba.fish\""
 
 if [ -f "$(which fish 2>/dev/null)" ]; then
     file="$HOME/.config/fish/config.fish"

--- a/jabba.fish
+++ b/jabba.fish
@@ -1,0 +1,15 @@
+# https://github.com/Jabba-Team/jabba
+# This file is intended to be "sourced" (i.e. ". ~/.jabba/jabba.fish")
+
+set -xg JABBA_HOME "$JABBA_HOME_TO_EXPORT"
+
+function jabba
+    set fd3 (mktemp /tmp/jabba-fd3.XXXXXX)
+    env JABBA_SHELL_INTEGRATION=ON $JABBA_BIN_TO_EXPORT/jabba $argv 3> $fd3
+    set exit_code $status
+    eval (cat $fd3 | sed "s/^export/set -xg/g" | sed "s/^unset/set -e/g" | tr '=' ' ' | sed "s/:/\" \"/g" | tr '\n' ';')
+    command rm -f $fd3
+    return $exit_code
+end
+
+[ -n (echo (jabba alias default)) ]; and jabba use default

--- a/jabba.sh
+++ b/jabba.sh
@@ -1,0 +1,16 @@
+# https://github.com/Jabba-Team/jabba
+# This file is intended to be "sourced" (i.e. ". ~/.jabba/jabba.sh")
+
+export JABBA_HOME="$JABBA_HOME_TO_EXPORT"
+
+jabba() {
+    local fd3
+    fd3=$(mktemp /tmp/jabba-fd3.XXXXXX)
+    (JABBA_SHELL_INTEGRATION=ON "$JABBA_BIN_TO_EXPORT/jabba" "$@" 3>| "${fd3}")
+    local exit_code=$?
+    eval "$(cat "${fd3}")"
+    command rm -f "${fd3}"
+    return ${exit_code}
+}
+
+[ -n "$(jabba alias default)" ] && jabba use default


### PR DESCRIPTION
Environment variables:
* `JABBA_BIN` is where the binary will be installed; defaults to `$JABBA_HOME/bin`
* `JABBA_BIN_TO_EXPORT` is where shell integration will invoke jabba; defaults to `\$HOME/.jabba/bin`
* `JABBA_SHARE` is where shell integration scripts are installed; defaults to `$JABBA_HOME`

These should allow package managers (like homebrew) to better control/sandbox where things are installed.