### PR TITLE
Fix none-make-install shell itegration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,8 +136,12 @@ mkdir -p "${JABBA_BIN}"
 
 if [ "$JABBA_MAKE_INSTALL" == "true" ]; then
     cp jabba "${JABBA_BIN}"
+    JABBA_SH="$(cat jabba.sh)"
+    JABBA_FISH="$(cat jabba.fish)"
 else
     $JABBA_GET "${BINARY_URL}" > "${JABBA_BIN}/jabba" && chmod a+x "${JABBA_BIN}/jabba"
+    JABBA_SH="$(${JABBA_GET} "https://github.com/Jabba-Team/jabba/raw/${JABBA_VERSION}/jabba.sh")"
+    JABBA_FISH="$(${JABBA_GET} "https://github.com/Jabba-Team/jabba/raw/${JABBA_VERSION}/jabba.fish")"
 fi
 
 if ! "${JABBA_BIN}/jabba" --version &>/dev/null; then
@@ -157,9 +161,9 @@ if [ "$JABBA_COMMAND" != "" ]; then
     fi
 fi
 
-sed -e "s=\$JABBA_HOME_TO_EXPORT=$JABBA_HOME_TO_EXPORT=g" -e "s=\$JABBA_BIN_TO_EXPORT=$JABBA_BIN_TO_EXPORT=g" jabba.sh > "${JABBA_SHARE}/jabba.sh"
+echo "$JABBA_SH" | sed -e "s=\$JABBA_HOME_TO_EXPORT=$JABBA_HOME_TO_EXPORT=g" -e "s=\$JABBA_BIN_TO_EXPORT=$JABBA_BIN_TO_EXPORT=g" > "${JABBA_SHARE}/jabba.sh"
 
-SOURCE_JABBA="\n[ -s \"$JABBA_SHARE/jabba.sh\" ] && source \"$JABBA_SHARE/jabba.sh\""
+SOURCE_JABBA="[ -s \"$JABBA_SHARE/jabba.sh\" ] && source \"$JABBA_SHARE/jabba.sh\""
 
 if [ ! "$SKIP_RC" ]; then
     files=("$HOME/.bashrc")
@@ -179,7 +183,7 @@ if [ ! "$SKIP_RC" ]; then
         touch "${file}"
         if ! grep -qc '/jabba.sh' "${file}"; then
             echo "Adding source string to ${file}"
-            printf "%s\n" "$SOURCE_JABBA" >> "${file}"
+            printf "\n%s\n" "$SOURCE_JABBA" >> "${file}"
         else
             echo "Skipped update of ${file} (source string already present)"
         fi
@@ -190,16 +194,16 @@ if [ ! "$SKIP_RC" ]; then
         touch "${file}"
         if ! grep -qc '/jabba.sh' "${file}"; then
             echo "Adding source string to ${file}"
-            printf "%s\n" "$SOURCE_JABBA" >> "${file}"
+            printf "\n%s\n" "$SOURCE_JABBA" >> "${file}"
         else
             echo "Skipped update of ${file} (source string already present)"
         fi
     fi
 fi
 
-sed -e "s=\$JABBA_HOME_TO_EXPORT=$JABBA_HOME_TO_EXPORT=g" -e "s=\$JABBA_BIN_TO_EXPORT=$JABBA_BIN_TO_EXPORT=g" jabba.fish > "${JABBA_SHARE}/jabba.fish"
+echo "$JABBA_FISH" | sed -e "s=\$JABBA_HOME_TO_EXPORT=$JABBA_HOME_TO_EXPORT=g" -e "s=\$JABBA_BIN_TO_EXPORT=$JABBA_BIN_TO_EXPORT=g" > "${JABBA_SHARE}/jabba.fish"
 
-FISH_SOURCE_JABBA="\n[ -s \"$JABBA_SHARE/jabba.fish\" ]; and source \"$JABBA_SHARE/jabba.fish\""
+FISH_SOURCE_JABBA="[ -s \"$JABBA_SHARE/jabba.fish\" ]; and source \"$JABBA_SHARE/jabba.fish\""
 
 if [ -f "$(which fish 2>/dev/null)" ]; then
     file="$HOME/.config/fish/config.fish"
@@ -207,7 +211,7 @@ if [ -f "$(which fish 2>/dev/null)" ]; then
     touch "${file}"
     if ! grep -qc '/jabba.fish' "${file}"; then
         echo "Adding source string to ${file}"
-        printf "%s\n" "$FISH_SOURCE_JABBA" >> "${file}"
+        printf "\n%s\n" "$FISH_SOURCE_JABBA" >> "${file}"
     else
         echo "Skipped update of ${file} (source string already present)"
     fi

--- a/jabba.fish
+++ b/jabba.fish
@@ -5,7 +5,7 @@ set -xg JABBA_HOME "$JABBA_HOME_TO_EXPORT"
 
 function jabba
     set fd3 (mktemp /tmp/jabba-fd3.XXXXXX)
-    env JABBA_SHELL_INTEGRATION=ON $JABBA_BIN_TO_EXPORT/jabba $argv 3> $fd3
+    env JABBA_SHELL_INTEGRATION=ON $JABBA_BIN_TO_EXPORT/jabba $argv --fd3 $fd3
     set exit_code $status
     eval (cat $fd3 | sed "s/^export/set -xg/g" | sed "s/^unset/set -e/g" | tr '=' ' ' | sed "s/:/\" \"/g" | tr '\n' ';')
     command rm -f $fd3

--- a/jabba.sh
+++ b/jabba.sh
@@ -9,6 +9,11 @@ jabba() {
     (JABBA_SHELL_INTEGRATION=ON "$JABBA_BIN_TO_EXPORT/jabba" "$@" --fd3 "${fd3}")
     local exit_code=$?
     eval "$(cat "${fd3}")"
+    case "$OSTYPE" in
+        cygwin*|msys*)
+            export PATH="$(/usr/bin/cygpath -p "${PATH}")"
+        ;;
+    esac
     command rm -f "${fd3}"
     return ${exit_code}
 }

--- a/jabba.sh
+++ b/jabba.sh
@@ -6,7 +6,7 @@ export JABBA_HOME="$JABBA_HOME_TO_EXPORT"
 jabba() {
     local fd3
     fd3=$(mktemp /tmp/jabba-fd3.XXXXXX)
-    (JABBA_SHELL_INTEGRATION=ON "$JABBA_BIN_TO_EXPORT/jabba" "$@" 3>| "${fd3}")
+    (JABBA_SHELL_INTEGRATION=ON "$JABBA_BIN_TO_EXPORT/jabba" "$@" --fd3 "${fd3}")
     local exit_code=$?
     eval "$(cat "${fd3}")"
     command rm -f "${fd3}"


### PR DESCRIPTION
Downloads the shell (bash, fish) integration functions from github.

Also makes the FD3 option more compatible with bash on Windows by using the `--fd3` flag instead of output redirection.

--

See #34 
Warning: When using this from Cygwin (Git Bash) the binary will still clobber the environment variables from the unix-style paths (`/c/Users/`) back to the Windows style (`c:\Users\`), thus breaking the shell in most cases.