### PR TITLE
add cache and read $JABBA_HOME/index.json support

### DIFF
--- a/command/ls-remote.go
+++ b/command/ls-remote.go
@@ -19,10 +19,10 @@ type byOS map[string]byArch
 type byArch map[string]byDistribution
 type byDistribution map[string]map[string]string
 
-var localCachePath = _os.Getenv("HOME") + "/.jabba/index.json"
+var localCachePath = cfg.Dir() + "/index.json"
 
 func LsRemote(os, arch string) (map[*semver.Version]string, error) {
-	// try read ~/.jabba/index.json first
+	// try read $JABBA_HOME/index.json first
 	var cnt, err = _os.ReadFile(localCachePath);
 	if err != nil{
 		cnt, err = fetch(cfg.Index())

--- a/command/ls-remote.go
+++ b/command/ls-remote.go
@@ -3,10 +3,13 @@ package command
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
+
+	_os "os"
 
 	"github.com/Jabba-Team/jabba/cfg"
 	"github.com/Jabba-Team/jabba/semver"
@@ -16,8 +19,16 @@ type byOS map[string]byArch
 type byArch map[string]byDistribution
 type byDistribution map[string]map[string]string
 
+var localCachePath = _os.Getenv("HOME") + "/.jabba/index.json"
+
 func LsRemote(os, arch string) (map[*semver.Version]string, error) {
-	cnt, err := fetch(cfg.Index())
+	// try read ~/.jabba/index.json first
+	var cnt, err = _os.ReadFile(localCachePath);
+	if err != nil{
+		cnt, err = fetch(cfg.Index())
+	} else {
+		fmt.Printf("use local cache index: %s need refresh, delete it\n", localCachePath)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -60,5 +71,6 @@ func fetch(url string) (content []byte, err error) {
 	if err != nil {
 		return
 	}
+	_os.WriteFile(localCachePath, content, 0644)
 	return
 }


### PR DESCRIPTION
Add support for cache and read  $JABBA_HOME/index.json

## Summary
- Try reading the index file from the user's home directory ` $JABBA_HOME/index.json` as the primary location
- Fall back to the original index http fetch if the home directory file does not exist or is unreadable
- No breaking changes

## Changes
- Attempt to read ` $JABBA_HOME/index.json` first
- Preserve existing behavior as fallback
- Save http fetch response content to ` $JABBA_HOME/index.json`